### PR TITLE
Fix linker compatibily on macOS

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -2,12 +2,15 @@
 # It is referenced with a --bazelrc option in the call to bazel in ci.yaml
 
 # Debug where options came from
-build --announce_rc
+common --announce_rc
 # This directory is configured in GitHub actions to be persisted between runs.
 # We do not enable the repository cache to cache downloaded external artifacts
 # as these are generally faster to download again than to fetch them from the
 # GitHub actions cache.
-build --disk_cache=~/.cache/bazel
+common --disk_cache=~/.cache/bazel
+# Better diagnostics for CI failures
+common --verbose_failures
+
 # Don't rely on test logs being easily accessible from the test runner,
 # though it makes the log noisier.
 test --test_output=errors

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,8 @@ jobs:
         [
           {"folder": ".", "bzlmodEnabled": false}
         ]
+      bazel_test_command: |
+        bazel --bazelrc=${GITHUB_WORKSPACE}/.github/workflows/ci.bazelrc test //...
   pre-commit:
     runs-on: ubuntu-latest
     steps:

--- a/d/private/rules/common.bzl
+++ b/d/private/rules/common.bzl
@@ -111,11 +111,11 @@ def compilation_action(ctx, target_type = TARGET_TYPE.LIBRARY):
     args.add_all(toolchain.compiler_flags)
     args.add_all(versions.to_list(), format_each = "-version=%s")
     args.add_all(toolchain.linker_flags)
-    for dep in d_deps:
-        args.add_all(dep.libraries)
-    args.add_all(c_libraries)
     output = None
     if target_type in [TARGET_TYPE.BINARY, TARGET_TYPE.TEST]:
+        for dep in d_deps:
+            args.add_all(dep.libraries)
+        args.add_all(c_libraries)
         if target_type == TARGET_TYPE.TEST:
             args.add_all(["-main", "-unittest"])
         output = ctx.actions.declare_file(_binary_name(ctx, ctx.label.name))


### PR DESCRIPTION
Fix error:
> `ld: warning: object file (bazel-out/darwin_x86_64-fastbuild/bin/d/tests/simple_c_library/libsimple_c_library.a[2](simple_library.o)) was built for newer 'macOS' version (14.2) than being linked (13.0)`